### PR TITLE
Improve ContactCard display of details

### DIFF
--- a/src/main/java/seedu/address/ui/ContactCard.java
+++ b/src/main/java/seedu/address/ui/ContactCard.java
@@ -16,7 +16,6 @@ import seedu.address.model.tag.Role;
 public class ContactCard extends UiPart<Region> {
 
     private static final String FXML = "ContactListCard.fxml";
-
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
      * As a consequence, UI elements' variable names cannot be set to such keywords
@@ -50,18 +49,19 @@ public class ContactCard extends UiPart<Region> {
     public ContactCard(Contact contact, int displayedIndex) {
         super(FXML);
         this.contact = contact;
+        final String nicknamePrelabel = "aka ";
+        final String telegramPrelabel = "@";
         id.setText(displayedIndex + ". ");
         name.setText(contact.getName().fullName);
-        telegramHandle.setText(contact.getTelegramHandle().value);
+        telegramHandle.setText(telegramPrelabel + contact.getTelegramHandle().value);
         studentStatus.setText(contact.getStudentStatus().value);
         email.setText(contact.getEmail().value);
         contact.getRoles().stream()
                 .sorted(Comparator.comparing(tag -> tag.roleName))
                 .forEach(role -> roles.getChildren().add(getRoleLabel(role)));
-
         String nicknameObtained = contact.getNickname().value;
         if (!nicknameObtained.isEmpty()) {
-            nickname.getChildren().add(new Label(nicknameObtained));
+            nickname.getChildren().add(new Label(nicknamePrelabel + nicknameObtained));
         }
     }
 

--- a/src/main/resources/view/ContactListCard.fxml
+++ b/src/main/resources/view/ContactListCard.fxml
@@ -27,11 +27,11 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
+      <FlowPane fx:id="nickname" />
       <FlowPane fx:id="roles" />
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="telegramHandle" styleClass="cell_small_label" text="\$telegramHandle" />
       <Label fx:id="studentStatus" styleClass="cell_small_label" text="\$studentStatus" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <FlowPane fx:id="nickname" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -337,6 +337,11 @@
     -fx-background-radius: 0;
 }
 
+
+#nickname .label {
+    -fx-font-size: 15;
+}
+
 #roles {
     -fx-hgap: 7;
     -fx-vgap: 3;


### PR DESCRIPTION
<img width="695" alt="image" src="https://github.com/user-attachments/assets/caffb29c-1002-4b76-82bd-94594e146619">
<br>Alternatively the person nickname can be at the side of the full name, though not recommended in the event someone's full name is super long.