### PR TITLE
Update find to search on AND instead of OR basis

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -30,11 +30,11 @@ public class FindCommand extends Command {
             + "[" + PREFIX_TELEGRAM_HANDLE + "TELEGRAM HANDLE KEYWORDS] "
             + "[" + PREFIX_EMAIL + "EMAIL KEYWORDS] "
             + "[" + PREFIX_STUDENT_STATUS + "STUDENT STATUS KEYWORDS] "
-            + "[" + PREFIX_ROLE + "ROLE KEYWORDS]"
+            + "[" + PREFIX_ROLE + "ROLE KEYWORDS]... "
             + "[" + PREFIX_NICKNAME + "NICKNAME KEYWORDS]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "alice bob charlie "
-            + PREFIX_ROLE + "pres admin";
+            + PREFIX_ROLE + "President " + PREFIX_ROLE + "Admin";
 
     private final Predicate<Contact> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -13,10 +13,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM_HANDLE;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.contact.ContainsKeywordsPredicate;
+import seedu.address.model.tag.Role;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -36,7 +38,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                         PREFIX_STUDENT_STATUS, PREFIX_ROLE, PREFIX_NICKNAME);
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TELEGRAM_HANDLE,
-                PREFIX_EMAIL, PREFIX_STUDENT_STATUS, PREFIX_ROLE, PREFIX_NICKNAME);
+                PREFIX_EMAIL, PREFIX_STUDENT_STATUS, PREFIX_NICKNAME);
 
         if (args.trim().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_NO_PARAMETER_FOUND, FindCommand.MESSAGE_USAGE));
@@ -73,9 +75,10 @@ public class FindCommandParser implements Parser<FindCommand> {
             String arg = argMultimap.getValue(PREFIX_NICKNAME).get();
             nicknameKeywords = getKeywords(arg);
         }
+
         if (argMultimap.getValue(PREFIX_ROLE).isPresent()) {
-            String arg = argMultimap.getValue(PREFIX_ROLE).get();
-            roleKeywords = getKeywords(arg);
+            Set<Role> roleList = ParserUtil.parseRoles(argMultimap.getAllValues(PREFIX_ROLE));
+            roleKeywords = roleList.stream().map(role -> role.roleName).toList();
         }
 
         ContainsKeywordsPredicate containsKeywordsPredicate =

--- a/src/main/java/seedu/address/model/contact/ContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/contact/ContainsKeywordsPredicate.java
@@ -41,20 +41,20 @@ public class ContainsKeywordsPredicate implements Predicate<Contact> {
     @Override
     public boolean test(Contact contact) {
         boolean containsNameKeywords = nameKeywords.stream()
-                .anyMatch(keyword -> StringUtil.containsIgnoreCase(contact.getName().fullName, keyword));
+                .allMatch(keyword -> StringUtil.containsIgnoreCase(contact.getName().fullName, keyword));
         boolean containsTelegramHandleKeywords = telegramHandleKeywords.stream()
-                .anyMatch(keyword -> StringUtil.containsIgnoreCase(contact.getTelegramHandle().value, keyword));
+                .allMatch(keyword -> StringUtil.containsIgnoreCase(contact.getTelegramHandle().value, keyword));
         boolean containsEmailKeywords = emailKeywords.stream()
-                .anyMatch(keyword -> StringUtil.containsIgnoreCase(contact.getEmail().value, keyword));
+                .allMatch(keyword -> StringUtil.containsIgnoreCase(contact.getEmail().value, keyword));
         boolean containsStudentStatusKeywords = studentStatusKeywords.stream()
-                .anyMatch(keyword -> StringUtil.containsIgnoreCase(contact.getStudentStatus().value, keyword));
+                .allMatch(keyword -> StringUtil.containsIgnoreCase(contact.getStudentStatus().value, keyword));
         boolean containsRoleKeywords = roleKeywords.stream()
-                .anyMatch(keyword -> contact.getRoles().stream()
+                .allMatch(keyword -> contact.getRoles().stream()
                         .anyMatch(role -> StringUtil.containsIgnoreCase(role.roleName, keyword)));
         boolean containsNicknameKeywords = nicknameKeywords.stream()
-                .anyMatch(keyword -> StringUtil.containsIgnoreCase(contact.getNickname().value, keyword));
-        return containsNameKeywords || containsTelegramHandleKeywords || containsEmailKeywords
-                || containsStudentStatusKeywords || containsRoleKeywords || containsNicknameKeywords;
+                .allMatch(keyword -> StringUtil.containsIgnoreCase(contact.getNickname().value, keyword));
+        return containsNameKeywords && containsTelegramHandleKeywords && containsEmailKeywords
+                && containsStudentStatusKeywords && containsRoleKeywords && containsNicknameKeywords;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/contact/ContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/contact/ContainsKeywordsPredicate.java
@@ -54,7 +54,7 @@ public class ContainsKeywordsPredicate implements Predicate<Contact> {
                 .allMatch(keyword -> StringUtil.containsIgnoreCase(contact.getStudentStatus().value, keyword));
         boolean containsRoleKeywords = roleKeywords.stream()
                 .allMatch(keyword -> contact.getRoles().stream()
-                        .anyMatch(role -> StringUtil.containsIgnoreCase(role.roleName, keyword)));
+                        .anyMatch(role -> role.roleName.equals(keyword)));
         boolean containsNicknameKeywords = nicknameKeywords.stream()
                 .allMatch(keyword -> StringUtil.containsIgnoreCase(contact.getNickname().value, keyword));
         return containsNameKeywords && containsTelegramHandleKeywords && containsEmailKeywords

--- a/src/main/java/seedu/address/model/contact/ContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/contact/ContainsKeywordsPredicate.java
@@ -1,5 +1,6 @@
 package seedu.address.model.contact;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -19,6 +20,7 @@ public class ContainsKeywordsPredicate implements Predicate<Contact> {
 
     /**
      * Constructs a {@code ContainsKeywordsPredicate}.
+     * At least one of the keyword lists must be non-empty.
      *
      * @param nameKeywords keywords to match with name
      * @param telegramHandleKeywords keywords to match with telegram handle
@@ -30,6 +32,8 @@ public class ContainsKeywordsPredicate implements Predicate<Contact> {
     public ContainsKeywordsPredicate(List<String> nameKeywords, List<String> telegramHandleKeywords,
                                      List<String> emailKeywords, List<String> studentStatusKeywords,
                                      List<String> roleKeywords, List<String> nicknameKeywords) {
+        assert !isAllEmpty(nameKeywords, telegramHandleKeywords, emailKeywords, studentStatusKeywords,
+                roleKeywords, nicknameKeywords);
         this.nameKeywords = nameKeywords;
         this.telegramHandleKeywords = telegramHandleKeywords;
         this.emailKeywords = emailKeywords;
@@ -90,5 +94,9 @@ public class ContainsKeywordsPredicate implements Predicate<Contact> {
                 .add("studentStatusKeywords", studentStatusKeywords)
                 .add("roleKeywords", roleKeywords)
                 .add("nicknameKeywords", nicknameKeywords).toString();
+    }
+
+    private static boolean isAllEmpty(List... lists) {
+        return Arrays.stream(lists).allMatch(List::isEmpty);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,13 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_CONTACTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalContacts.BENSON;
 import static seedu.address.testutil.TypicalContacts.CARL;
-import static seedu.address.testutil.TypicalContacts.ELLE;
-import static seedu.address.testutil.TypicalContacts.FIONA;
+import static seedu.address.testutil.TypicalContacts.DANIEL;
 import static seedu.address.testutil.TypicalContacts.getTypicalAddressBook;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +18,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.contact.ContainsKeywordsPredicate;
+import seedu.address.testutil.ContainsKeywordsPredicateBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -29,12 +29,15 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        ContainsKeywordsPredicate firstPredicate = new ContainsKeywordsPredicate(
-                Collections.singletonList("first"), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-        ContainsKeywordsPredicate secondPredicate = new ContainsKeywordsPredicate(
-                Collections.singletonList("second"), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        ContainsKeywordsPredicate firstPredicate =
+                new ContainsKeywordsPredicateBuilder().withNameKeywords("first").withTelegramHandleKeywords("first")
+                        .withEmailKeywords("first").withStudentStatusKeywords("first").withRoleKeywords("first")
+                        .withNicknameKeywords("first").build();
+        ContainsKeywordsPredicate secondPredicate =
+                new ContainsKeywordsPredicateBuilder().withNameKeywords("first", "second")
+                        .withTelegramHandleKeywords("first", "second").withEmailKeywords("first", "second")
+                        .withStudentStatusKeywords("first", "second").withRoleKeywords("first", "second")
+                        .withNicknameKeywords("first", "second").build();
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -57,40 +60,43 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noContactFound() {
-        String expectedMessage = String.format(MESSAGE_CONTACTS_LISTED_OVERVIEW, 0);
-        ContainsKeywordsPredicate predicate = preparePredicate(" ");
+    public void execute_multipleMatchingKeywords_oneContactFound() {
+        String expectedMessage = String.format(MESSAGE_CONTACTS_LISTED_OVERVIEW, 1);
+        ContainsKeywordsPredicate predicate =
+                new ContainsKeywordsPredicateBuilder().withNameKeywords("Kurz", "Carl").build();
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredContactList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredContactList());
+        assertEquals(Arrays.asList(CARL), model.getFilteredContactList());
     }
 
     @Test
-    public void execute_multipleKeywords_multipleContactsFound() {
-        String expectedMessage = String.format(MESSAGE_CONTACTS_LISTED_OVERVIEW, 3);
-        ContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+    public void execute_oneMatchingKeyword_multipleContactsFound() {
+        String expectedMessage = String.format(MESSAGE_CONTACTS_LISTED_OVERVIEW, 2);
+        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Meier").build();
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredContactList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredContactList());
+        assertEquals(Arrays.asList(BENSON, DANIEL), model.getFilteredContactList());
+    }
+
+    @Test
+    public void execute_multipleMatchingKeywords_multipleContactsFound() {
+        String expectedMessage = String.format(MESSAGE_CONTACTS_LISTED_OVERVIEW, 2);
+        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Meier")
+                .withStudentStatusKeywords("undergrad").build();
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredContactList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, DANIEL), model.getFilteredContactList());
     }
 
     @Test
     public void toStringMethod() {
-        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicate(
-                Arrays.asList("keyword"), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        ContainsKeywordsPredicate predicate =
+                new ContainsKeywordsPredicateBuilder().withNameKeywords("keyword").build();
         FindCommand findCommand = new FindCommand(predicate);
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findCommand.toString());
-    }
-
-    /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
-     */
-    private ContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new ContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_EMPTY_PREFIX_FIELD;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_NO_PARAMETER_FOUND;
+import static seedu.address.logic.commands.CommandTestUtil.ROLE_DESC_ADMIN;
 import static seedu.address.logic.commands.CommandTestUtil.ROLE_DESC_PRESIDENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -14,7 +15,6 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.contact.ContainsKeywordsPredicate;
+import seedu.address.model.tag.Role;
+import seedu.address.testutil.ContainsKeywordsPredicateBuilder;
 
 public class FindCommandParserTest {
 
@@ -32,20 +34,22 @@ public class FindCommandParserTest {
     private static final List<String> TELEGRAM_HANDLE_KEYWORD_LIST = Arrays.asList("amy", "123");
     private static final List<String> EMAIL_KEYWORD_LIST = Arrays.asList("gmail", "amy");
     private static final List<String> STUDENT_STATUS_KEYWORD_LIST = Arrays.asList("Undergrad", "phd");
-    private static final List<String> ROLE_KEYWORD_LIST = Arrays.asList("pres", "Admin");
+    private static final List<String> ROLE_KEYWORD_LIST = Arrays.asList("President", "Admin");
     private static final List<String> NICKNAME_KEYWORD_LIST = Arrays.asList("amy", "bob");
     private static final String NAME_QUERY = " " + PREFIX_NAME + "amy Bob";
     private static final String TELEGRAM_HANDLE_QUERY = " " + PREFIX_TELEGRAM_HANDLE + "amy 123";
     private static final String EMAIL_QUERY = " " + PREFIX_EMAIL + "gmail amy";
     private static final String STUDENT_STATUS_QUERY = " " + PREFIX_STUDENT_STATUS + "Undergrad phd";
-    private static final String ROLE_QUERY = " " + PREFIX_ROLE + "pres Admin";
+    private static final String PRESIDENT_ROLE_QUERY = ROLE_DESC_PRESIDENT;
+    private static final String INVALID_ROLE_QUERY = " " + PREFIX_ROLE + "invalid role";
+    private static final String ADMIN_ROLE_QUERY = ROLE_DESC_ADMIN;
     private static final String NICKNAME_QUERY = " " + PREFIX_NICKNAME + "amy bob";
 
     private FindCommandParser parser = new FindCommandParser();
 
     @Test
     public void parse_missingParts_throwsParseException() {
-        // no prefix and no arguments
+        // no arguments
         assertParseFailure(parser, "     ", String.format(MESSAGE_NO_PARAMETER_FOUND, FindCommand.MESSAGE_USAGE));
 
         // no prefix
@@ -60,12 +64,14 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        String userInput = NAME_QUERY + ROLE_QUERY + EMAIL_QUERY
+        String userInput = NAME_QUERY + PRESIDENT_ROLE_QUERY + ADMIN_ROLE_QUERY + EMAIL_QUERY
                 + STUDENT_STATUS_QUERY + NICKNAME_QUERY + TELEGRAM_HANDLE_QUERY;
 
         ContainsKeywordsPredicate predicate =
-                new ContainsKeywordsPredicate(NAME_KEYWORD_LIST, TELEGRAM_HANDLE_KEYWORD_LIST, EMAIL_KEYWORD_LIST,
-                        STUDENT_STATUS_KEYWORD_LIST, ROLE_KEYWORD_LIST, NICKNAME_KEYWORD_LIST);
+                new ContainsKeywordsPredicateBuilder().withNameKeywords(NAME_KEYWORD_LIST)
+                        .withTelegramHandleKeywords(TELEGRAM_HANDLE_KEYWORD_LIST).withEmailKeywords(EMAIL_KEYWORD_LIST)
+                        .withStudentStatusKeywords(STUDENT_STATUS_KEYWORD_LIST).withRoleKeywords(ROLE_KEYWORD_LIST)
+                        .withNicknameKeywords(NICKNAME_KEYWORD_LIST).build();
         FindCommand expectedCommand = new FindCommand(predicate);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -73,11 +79,11 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        String userInput = NAME_QUERY + ROLE_QUERY + EMAIL_QUERY;
+        String userInput = NAME_QUERY + PRESIDENT_ROLE_QUERY + ADMIN_ROLE_QUERY + EMAIL_QUERY;
 
         ContainsKeywordsPredicate predicate =
-                new ContainsKeywordsPredicate(NAME_KEYWORD_LIST, Collections.emptyList(), EMAIL_KEYWORD_LIST,
-                        Collections.emptyList(), ROLE_KEYWORD_LIST, Collections.emptyList());
+                new ContainsKeywordsPredicateBuilder().withNameKeywords(NAME_KEYWORD_LIST)
+                        .withEmailKeywords(EMAIL_KEYWORD_LIST).withRoleKeywords(ROLE_KEYWORD_LIST).build();
         FindCommand expectedCommand = new FindCommand(predicate);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -88,45 +94,47 @@ public class FindCommandParserTest {
         // name
         String userInput = NAME_QUERY;
         ContainsKeywordsPredicate predicate =
-                new ContainsKeywordsPredicate(NAME_KEYWORD_LIST, Collections.emptyList(), Collections.emptyList(),
-                        Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+                new ContainsKeywordsPredicateBuilder().withNameKeywords(NAME_KEYWORD_LIST).build();
         FindCommand expectedCommand = new FindCommand(predicate);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // telegramHandle
         userInput = TELEGRAM_HANDLE_QUERY;
-        predicate = new ContainsKeywordsPredicate(Collections.emptyList(), TELEGRAM_HANDLE_KEYWORD_LIST,
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        predicate =
+                new ContainsKeywordsPredicateBuilder().withTelegramHandleKeywords(TELEGRAM_HANDLE_KEYWORD_LIST).build();
         expectedCommand = new FindCommand(predicate);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
         userInput = EMAIL_QUERY;
-        predicate = new ContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(), EMAIL_KEYWORD_LIST,
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        predicate = new ContainsKeywordsPredicateBuilder().withEmailKeywords(EMAIL_KEYWORD_LIST).build();
         expectedCommand = new FindCommand(predicate);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // student status
         userInput = STUDENT_STATUS_QUERY;
-        predicate = new ContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), STUDENT_STATUS_KEYWORD_LIST, Collections.emptyList(), Collections.emptyList());
+        predicate =
+                new ContainsKeywordsPredicateBuilder().withStudentStatusKeywords(STUDENT_STATUS_KEYWORD_LIST).build();
         expectedCommand = new FindCommand(predicate);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // role
-        userInput = ROLE_QUERY;
-        predicate = new ContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), ROLE_KEYWORD_LIST, Collections.emptyList());
+        userInput = PRESIDENT_ROLE_QUERY + ADMIN_ROLE_QUERY;
+        predicate = new ContainsKeywordsPredicateBuilder().withRoleKeywords(ROLE_KEYWORD_LIST).build();
         expectedCommand = new FindCommand(predicate);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // nickname
         userInput = NICKNAME_QUERY;
-        predicate = new ContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), NICKNAME_KEYWORD_LIST);
+        predicate = new ContainsKeywordsPredicateBuilder().withNicknameKeywords(NICKNAME_KEYWORD_LIST).build();
         expectedCommand = new FindCommand(predicate);
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidRoleValue_failure() {
+        String userInput = INVALID_ROLE_QUERY;
+        assertParseFailure(parser, userInput, Role.MESSAGE_CONSTRAINTS);
     }
 
     @Test
@@ -140,8 +148,9 @@ public class FindCommandParserTest {
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
         // mulltiple valid fields repeated
-        userInput = NAME_QUERY + ROLE_QUERY + STUDENT_STATUS_QUERY + NAME_QUERY + ROLE_QUERY + STUDENT_STATUS_QUERY;
+        userInput = NAME_QUERY + PRESIDENT_ROLE_QUERY + ADMIN_ROLE_QUERY + STUDENT_STATUS_QUERY
+                + NAME_QUERY + STUDENT_STATUS_QUERY;
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ROLE, PREFIX_STUDENT_STATUS));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_STUDENT_STATUS));
     }
 }

--- a/src/test/java/seedu/address/model/contact/ContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/contact/ContainsKeywordsPredicateTest.java
@@ -3,36 +3,37 @@ package seedu.address.model.contact;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalContacts.ALICE;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.ContactBuilder;
+import seedu.address.testutil.ContainsKeywordsPredicateBuilder;
 
 public class ContainsKeywordsPredicateTest {
 
     @Test
     public void equals() {
-        List<String> firstPredicateKeywordList = Collections.singletonList("first");
-        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
-
-        ContainsKeywordsPredicate firstPredicate = new ContainsKeywordsPredicate(
-                firstPredicateKeywordList, firstPredicateKeywordList, firstPredicateKeywordList,
-                firstPredicateKeywordList, firstPredicateKeywordList, firstPredicateKeywordList);
-        ContainsKeywordsPredicate secondPredicate = new ContainsKeywordsPredicate(
-                secondPredicateKeywordList, secondPredicateKeywordList, secondPredicateKeywordList,
-                secondPredicateKeywordList, secondPredicateKeywordList, secondPredicateKeywordList);
+        ContainsKeywordsPredicate firstPredicate =
+                new ContainsKeywordsPredicateBuilder().withNameKeywords("first").withTelegramHandleKeywords("first")
+                        .withEmailKeywords("first").withStudentStatusKeywords("first").withRoleKeywords("first")
+                        .withNicknameKeywords("first").build();
+        ContainsKeywordsPredicate secondPredicate =
+                new ContainsKeywordsPredicateBuilder().withNameKeywords("first", "second")
+                        .withTelegramHandleKeywords("first", "second").withEmailKeywords("first", "second")
+                        .withStudentStatusKeywords("first", "second").withRoleKeywords("first", "second")
+                        .withNicknameKeywords("first", "second").build();
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        ContainsKeywordsPredicate firstPredicateCopy = new ContainsKeywordsPredicate(
-                firstPredicateKeywordList, firstPredicateKeywordList, firstPredicateKeywordList,
-                firstPredicateKeywordList, firstPredicateKeywordList, firstPredicateKeywordList);
+        ContainsKeywordsPredicate firstPredicateCopy =
+                new ContainsKeywordsPredicateBuilder().withNameKeywords("first").withTelegramHandleKeywords("first")
+                        .withEmailKeywords("first").withStudentStatusKeywords("first").withRoleKeywords("first")
+                        .withNicknameKeywords("first").build();
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -41,103 +42,96 @@ public class ContainsKeywordsPredicateTest {
         // null -> returns false
         assertFalse(firstPredicate.equals(null));
 
-        // different contact -> returns false
+        // differs in only one field -> returns false
+        ContainsKeywordsPredicate differentNameKeywordsFirstPredicate =
+                new ContainsKeywordsPredicateBuilder().withNameKeywords("first", "second")
+                        .withTelegramHandleKeywords("first").withEmailKeywords("first")
+                        .withStudentStatusKeywords("first").withRoleKeywords("first")
+                        .withNicknameKeywords("first").build();
+        assertFalse(firstPredicate.equals(differentNameKeywordsFirstPredicate));
+
+        // different number of fields -> returns false
+        ContainsKeywordsPredicate noNameKeywordsFirstPredicate =
+                new ContainsKeywordsPredicateBuilder().withTelegramHandleKeywords("first").withEmailKeywords("first")
+                        .withStudentStatusKeywords("first").withRoleKeywords("first")
+                        .withNicknameKeywords("first").build();
+        assertFalse(firstPredicate.equals(noNameKeywordsFirstPredicate));
+
+        // different ContainsKeywordsPredicate -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));
     }
 
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
-        // One keyword
-        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicate(
-                Collections.singletonList("Alice"), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        // One name keyword
+        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Alice").build();
         assertTrue(predicate.test(new ContactBuilder().withName("Alice Bob").build()));
 
-        // Multiple keywords
-        predicate = new ContainsKeywordsPredicate(
-                Arrays.asList("Alice", "Bob"), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        // Multiple name keywords
+        predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Alice", "Bob").build();
         assertTrue(predicate.test(new ContactBuilder().withName("Alice Bob").build()));
 
-        // Only one matching keyword
-        predicate = new ContainsKeywordsPredicate(
-                Arrays.asList("Bob", "Carol"), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-        assertTrue(predicate.test(new ContactBuilder().withName("Alice Carol").build()));
-
-        // Mixed-case keywords
-        predicate = new ContainsKeywordsPredicate(
-                Arrays.asList("aLIce", "bOB"), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        // Mixed-case name keywords
+        predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("aLIce", "bOB").build();
         assertTrue(predicate.test(new ContactBuilder().withName("Alice Bob").build()));
 
-        // Substring keywords
-        predicate = new ContainsKeywordsPredicate(
-                Arrays.asList("Lic", "OB"), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList());
+        // Substring name keywords
+        predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Lic", "OB").build();
         assertTrue(predicate.test(new ContactBuilder().withName("Alice Bob").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicate(
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-        assertFalse(predicate.test(new ContactBuilder().withName("Alice").build()));
-
-        // Non-matching keyword
-        predicate = new ContainsKeywordsPredicate(
-                Arrays.asList("Carol"), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        // Non-matching name keyword
+        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Carol").build();
         assertFalse(predicate.test(new ContactBuilder().withName("Alice Bob").build()));
 
-        // nameKeywords match phone, email and address, but does not match name
-        predicate = new ContainsKeywordsPredicate(Arrays.asList(
-                "12345", "alice@email.com", "Main", "Street"), Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        // Only one matching name keyword
+        predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Bob", "Carol").build();
+        assertFalse(predicate.test(new ContactBuilder().withName("Alice Carol").build()));
+
+        // name keywords match phone, email and address, but does not match name
+        predicate = new ContainsKeywordsPredicateBuilder()
+                .withNameKeywords("12345", "alice@email.com", "Main", "Street").build();
         assertFalse(predicate.test(new ContactBuilder().withName("Alice").withTelegramHandle("12345")
                 .withEmail("alice@email.com").withStudentStatus("undergraduate 1").build()));
     }
 
     @Test
-    public void test_roleContainsKeywords_returnsTrue() {
-        // One keyword
-        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicate(
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                Collections.singletonList("President"), Collections.emptyList());
-        assertTrue(predicate.test(new ContactBuilder().withRoles("President", "Admin").build()));
+    public void test_multipleFieldsAllMatch_returnsTrue() {
+        // Two matching fields
+        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Alice")
+                .withRoleKeywords("Admin").build();
+        assertTrue(predicate.test(ALICE));
 
-        // Multiple keywords
-        predicate = new ContainsKeywordsPredicate(
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                Arrays.asList("President", "Admin"), Collections.emptyList());
-        assertTrue(predicate.test(new ContactBuilder().withRoles("President", "Admin").build()));
+        // All matching fields
+        predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Alice")
+                .withTelegramHandleKeywords("94351253")
+                .withEmailKeywords("alice").withStudentStatusKeywords("undergrad").withRoleKeywords("Admin")
+                .withNicknameKeywords("nickname").build();
+        assertTrue(predicate.test(new ContactBuilder(ALICE).withNickname("nickname").build()));
+    }
 
-        // Only one matching keyword
-        predicate = new ContainsKeywordsPredicate(
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                Arrays.asList("President", "Relations"), Collections.emptyList());
-        assertTrue(predicate.test(new ContactBuilder().withRoles("External Relations", "Admin").build()));
+    @Test
+    public void test_multipleFieldsOnlySomeMatch_returnsFalse() {
+        // Name matches but role does not match
+        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Alice")
+                .withRoleKeywords("President").build();
+        assertFalse(predicate.test(ALICE));
 
-        // Mixed-case keywords
-        predicate = new ContainsKeywordsPredicate(
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                Arrays.asList("pResIdent", "aDmiN"), Collections.emptyList());
-        assertTrue(predicate.test(new ContactBuilder().withRoles("President", "Admin").build()));
-
-        // Substring keywords
-        predicate = new ContainsKeywordsPredicate(
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                Arrays.asList("pres", "min"), Collections.emptyList());
-        assertTrue(predicate.test(new ContactBuilder().withRoles("President", "Admin").build()));
+        // All fields match except for name
+        predicate = new ContainsKeywordsPredicateBuilder().withNameKeywords("Alice", "Bob")
+                .withTelegramHandleKeywords("94351253")
+                .withEmailKeywords("alice").withStudentStatusKeywords("undergrad").withRoleKeywords("Admin")
+                .withNicknameKeywords("nickname").build();
+        assertFalse(predicate.test(new ContactBuilder(ALICE).withNickname("nickname").build()));
     }
 
     @Test
     public void toStringMethod() {
         List<String> keywords = List.of("keyword1", "keyword2");
-        ContainsKeywordsPredicate predicate = new ContainsKeywordsPredicate(keywords, Collections.emptyList(),
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        ContainsKeywordsPredicate predicate =
+                new ContainsKeywordsPredicateBuilder().withNameKeywords("keyword1", "keyword2").build();
 
         String expected = ContainsKeywordsPredicate.class.getCanonicalName() + "{nameKeywords=" + keywords + ", "
                 + "telegramHandleKeywords=[], emailKeywords=[], studentStatusKeywords=[], roleKeywords=[], "

--- a/src/test/java/seedu/address/testutil/ContainsKeywordsPredicateBuilder.java
+++ b/src/test/java/seedu/address/testutil/ContainsKeywordsPredicateBuilder.java
@@ -1,0 +1,95 @@
+package seedu.address.testutil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import seedu.address.model.contact.ContainsKeywordsPredicate;
+
+/**
+ * A utility class to help with building ContainsKeywordsPredicate objects.
+ */
+public class ContainsKeywordsPredicateBuilder {
+
+    public static final List<String> DEFAULT_NAME_KEYWORDS = Collections.emptyList();
+    public static final List<String> DEFAULT_TELEGRAM_KEYWORDS = Collections.emptyList();
+    public static final List<String> DEFAULT_EMAIL_KEYWORDS = Collections.emptyList();
+    public static final List<String> DEFAULT_STUDENT_STATUS_KEYWORDS = Collections.emptyList();
+    public static final List<String> DEFAULT_ROLE_KEYWORDS = Collections.emptyList();
+    public static final List<String> DEFAULT_NICKNAME_KEYWORDS = Collections.emptyList();
+
+    private List<String> nameKeywords;
+    private List<String> telegramHandleKeywords;
+    private List<String> emailKeywords;
+    private List<String> studentStatusKeywords;
+    private List<String> roleKeywords;
+    private List<String> nicknameKeywords;
+
+    /**
+     * Creates a {@code ContainsKeywordsPredicateBuilder} with the default details.
+     */
+    public ContainsKeywordsPredicateBuilder() {
+        nameKeywords = DEFAULT_NAME_KEYWORDS;
+        telegramHandleKeywords = DEFAULT_TELEGRAM_KEYWORDS;
+        emailKeywords = DEFAULT_EMAIL_KEYWORDS;
+        studentStatusKeywords = DEFAULT_STUDENT_STATUS_KEYWORDS;
+        roleKeywords = DEFAULT_ROLE_KEYWORDS;
+        nicknameKeywords = DEFAULT_NICKNAME_KEYWORDS;
+    }
+
+    /**
+     * Sets the {@code nameKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withNameKeywords(String ... nameKeywords) {
+        this.nameKeywords = Arrays.asList(nameKeywords);
+        return this;
+    }
+
+    /**
+     * Sets the {@code telegramHandleKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withTelegramHandleKeywords(String ... telegramHandleKeywords) {
+        this.telegramHandleKeywords = Arrays.asList(telegramHandleKeywords);
+        return this;
+    }
+
+    /**
+     * Sets the {@code emailKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withEmailKeywords(String ... emailKeywords) {
+        this.emailKeywords = Arrays.asList(emailKeywords);
+        return this;
+    }
+
+    /**
+     * Sets the {@code studentStatusKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withStudentStatusKeywords(String ... studentStatusKeywords) {
+        this.studentStatusKeywords = Arrays.asList(studentStatusKeywords);
+        return this;
+    }
+
+    /**
+     * Sets the {@code roleKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withRoleKeywords(String ... roleKeywords) {
+        this.roleKeywords = Arrays.asList(roleKeywords);
+        return this;
+    }
+
+    /**
+     * Sets the {@code nicknameKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withNicknameKeywords(String ... nicknameKeywords) {
+        this.nicknameKeywords = Arrays.asList(nicknameKeywords);
+        return this;
+    }
+
+    /**
+     * Builds a {@code ContainsKeywordsPredicate}.
+     */
+    public ContainsKeywordsPredicate build() {
+        return new ContainsKeywordsPredicate(nameKeywords, telegramHandleKeywords, emailKeywords, studentStatusKeywords,
+                roleKeywords, nicknameKeywords);
+    }
+}

--- a/src/test/java/seedu/address/testutil/ContainsKeywordsPredicateBuilder.java
+++ b/src/test/java/seedu/address/testutil/ContainsKeywordsPredicateBuilder.java
@@ -46,10 +46,26 @@ public class ContainsKeywordsPredicateBuilder {
     }
 
     /**
+     * Sets the {@code nameKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withNameKeywords(List<String> nameKeywords) {
+        this.nameKeywords = nameKeywords;
+        return this;
+    }
+
+    /**
      * Sets the {@code telegramHandleKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
      */
     public ContainsKeywordsPredicateBuilder withTelegramHandleKeywords(String ... telegramHandleKeywords) {
         this.telegramHandleKeywords = Arrays.asList(telegramHandleKeywords);
+        return this;
+    }
+
+    /**
+     * Sets the {@code telegramHandleKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withTelegramHandleKeywords(List<String> telegramHandleKeywords) {
+        this.telegramHandleKeywords = telegramHandleKeywords;
         return this;
     }
 
@@ -62,10 +78,26 @@ public class ContainsKeywordsPredicateBuilder {
     }
 
     /**
+     * Sets the {@code emailKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withEmailKeywords(List<String> emailKeywords) {
+        this.emailKeywords = emailKeywords;
+        return this;
+    }
+
+    /**
      * Sets the {@code studentStatusKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
      */
     public ContainsKeywordsPredicateBuilder withStudentStatusKeywords(String ... studentStatusKeywords) {
         this.studentStatusKeywords = Arrays.asList(studentStatusKeywords);
+        return this;
+    }
+
+    /**
+     * Sets the {@code studentStatusKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withStudentStatusKeywords(List<String> studentStatusKeywords) {
+        this.studentStatusKeywords = studentStatusKeywords;
         return this;
     }
 
@@ -78,10 +110,26 @@ public class ContainsKeywordsPredicateBuilder {
     }
 
     /**
+     * Sets the {@code roleKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withRoleKeywords(List<String> roleKeywords) {
+        this.roleKeywords = roleKeywords;
+        return this;
+    }
+
+    /**
      * Sets the {@code nicknameKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
      */
     public ContainsKeywordsPredicateBuilder withNicknameKeywords(String ... nicknameKeywords) {
         this.nicknameKeywords = Arrays.asList(nicknameKeywords);
+        return this;
+    }
+
+    /**
+     * Sets the {@code nicknameKeywords} of the {@code ContainsKeywordsPredicate} that we are building.
+     */
+    public ContainsKeywordsPredicateBuilder withNicknameKeywords(List<String> nicknameKeywords) {
+        this.nicknameKeywords = nicknameKeywords;
         return this;
     }
 


### PR DESCRIPTION
- multiple r/ to be used to find multiple roles, i.e. find r/President r/Admin
- role field can only take valid role values (same as add and edit, error will be thrown otherwise)

- find n/amy ben will match Amy Ben and Samy Benjamin, but will not match Amy Tan or Ben Liew
- ContainsKeywordsPredicateBuilder to be used when testing find related classes (similar to ContactBuilder)